### PR TITLE
experimented with pixelcopy.array_to_surface / surface_to_array.

### DIFF
--- a/rendering/threedee.py
+++ b/rendering/threedee.py
@@ -189,6 +189,9 @@ if __name__ == "__main__":
                     neon_renderer.set_enabled(use_neon)
                 elif e.key == pygame.K_p:
                     profiling.get_instance().toggle()
+                elif e.key == pygame.K_m:
+                    neon_renderer.draw_mode = 1 if neon_renderer.draw_mode == 2 else 2
+                    print("Switching to render mode: {} ({})".format(neon_renderer.draw_mode, "pixelcopy" if neon_renderer.draw_mode == 2 else "blit_array"))
 
         keys_held = pygame.key.get_pressed()
         if keys_held[pygame.K_LEFT] or keys_held[pygame.K_RIGHT]:


### PR DESCRIPTION
See draw_lines2. Swapped out `pygame.surfarray.blit_array(surface, array)` with pygame.pixelcopy calls. I believe I did things correctly, and yet the results are even worse. Using pixelcopy the FPS is about 24 at 1400 x 800, vs about 40 using blit_array. You can try for yourself by running threedee and toggling between the two methods using the 'm' key.

Anyways, don't land this, and I'm done messing with it. The original code is fine and I'm not convinced there will be an easy fix here, since all these methods are doing essentially the same thing. 

Let's finish the game instead